### PR TITLE
Enable event reupload UI button for uploaded recordings

### DIFF
--- a/ui/func.js
+++ b/ui/func.js
@@ -192,7 +192,7 @@ window.onload = function () {
                             <font-awesome-icon icon="exclamation-triangle" />
                             </span>
                             <span class=action
-                                  v-if="event.status == 'failed uploading'"
+                                  v-if="event.status == 'failed uploading' || event.status == 'finished uploading'"
                                   v-on:click="retry_ingest(event)"
                                   title="Retry upload">
                                 <font-awesome-icon icon="sync" v-bind:class="{ 'fa-spin': event.processing }" />


### PR DESCRIPTION
In some conditions you want to reupload the recording even if the previous upload was successfully finished. This patch enable the UI reupload button on finished upload recordings.
![image](https://user-images.githubusercontent.com/26736/95342915-37511f00-08b8-11eb-89e4-1b2e6ebb7ea8.png)
