### PR TITLE
Skip catalog ingest option added

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -142,6 +142,13 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Default: False
 #delete_after_upload = False
 
+# Skip ingesting metadata catalogs to Opencast. If you set this option to True,
+# Opencast will use the metadata catalogs from the scheduler service and do not
+# override these by the uploaded version from pyCA.
+# Type: boolean
+# Default: False
+# skip_catalogs   = False
+
 
 [server]
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -36,6 +36,7 @@ exit_code        = integer(min=0, max=255, default=0)
 
 [ingest]
 delete_after_upload = boolean(default=false)
+skip_catalogs    = boolean(default=false)
 
 [server]
 url              = string(default='https://develop.opencast.org')

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -71,6 +71,10 @@ def ingest(event):
         # Check for dublincore catalogs
         elif attachment.get('fmttype') == 'application/xml' and dcns in data:
             name = attachment.get('x-apple-filename', '').rsplit('.', 1)[0]
+            if config('ingest', 'skip_catalogs'):
+                logger.info(
+                    'Skipping adding catalog %s due to configuration', name)
+                continue
             logger.info('Adding %s DC catalog', name)
             fields = [('mediaPackage', mediapackage),
                       ('flavor', 'dublincore/%s' % name),


### PR DESCRIPTION
If you set skip_catalogs option in the ingest section to true, pyCA will skip ingesting metadata catalogs to Opencast.